### PR TITLE
Processing on init to avoid headers already sent issues.

### DIFF
--- a/includes/classes/pmpro-testimonial-form.php
+++ b/includes/classes/pmpro-testimonial-form.php
@@ -44,9 +44,6 @@ class PMPro_Testimonial_Form {
 
 	public function display( $echo = true ) {
 
-		// Process it here so we can change what we output based on the result.
-		$this->process();
-
 		// If we are on the success message page, show it and bail.
 		if ( isset( $_GET['testimonial_success'] ) ) {
 			$message = get_option( 'pmpro_testimonials_confirmation_message' );

--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -29,3 +29,12 @@ function pmpro_testimonials_custom_query_loop_schema_attrs( $block_content, $blo
 	return $block_content;
 }
 add_filter( 'render_block', 'pmpro_testimonials_custom_query_loop_schema_attrs', 10, 2 );
+
+// Process the form submission.
+function pmpro_testimonials_process_form_submission() {
+	if ( ! empty( $_POST['pmpro_testimonials_nonce'] ) ) {
+		$form = new PMPro_Testimonial_Form();
+		$form->process();
+	}
+}
+add_action( 'init', 'pmpro_testimonials_process_form_submission' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-testimonials/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The form used to process within the display method. The issue here was that method was only running when the shortcode was being output, which means you will get a "headers already sent" error when trying to redirect after processing.

The solution used here was to remove the process call from within the display method and instead call it on init. The code process on init was added to the includes/hooks.php file.

We are double checking for the testimonials nonce in the post. This avoids a bit of memory loading the form instance if we're not processing a form and will avoid issues if the process method is changed in the future to do things even if the nonce isn't present. This does mean things will break if the name of the nonce is changed. We maybe just want to load the form class and run the process method and let that method check if it's really needed. If so, make sure to comment on things.

### How to test the changes in this Pull Request:

1. Add the testimonials form to a page `[pmpro_testimonials_form /]`
2. Submit the form.
3. If you had a redirect on submission, it should work. If you had a message, it should be shown.

### Other information:

* [] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX: Fixed issues with redirects and messages after submitting the add testimonial form.
