### PR TITLE
Resolve default image gravatar conflict; adding "shortcode examples" to settings

### DIFF
--- a/includes/adminpages/settings.php
+++ b/includes/adminpages/settings.php
@@ -77,6 +77,7 @@
 								)
 							);
 							?>
+							<p class="description"><?php esc_html_e( 'This message will be displayed to the member after they submit a testimonial. If you clear this field, a default system message will be displayed.', 'pmpro-testimonials' ); ?></p>
 						</td>
 					</tr>
 

--- a/includes/adminpages/settings.php
+++ b/includes/adminpages/settings.php
@@ -111,12 +111,44 @@
 							<input type="hidden" id="pmpro_testimonials_default_image" name="pmpro_testimonials_default_image" value="<?php echo esc_attr( $testimonial_image_id ); ?>" />
 							<button type="button" class="button" id="pmpro_testimonial_image_button"><?php esc_html_e( 'Select Image', 'pmpro-testimonials' ); ?></button>
 							<button type="button" class="button" id="pmpro_testimonial_image_remove"><?php esc_html_e( 'Remove Image', 'pmpro-testimonials' ); ?></button>
+							<p class="description"><?php esc_html_e( 'Note: The image must be hosted on a publicly accessible website. Images stored locally or in development environments may not load correctly.', 'pmpro-testimonials' ); ?></p>
 						</td>
 					</tr>
 
 				</table>
 			</div> <!-- end pmpro_section_inside -->
 		</div> <!-- end pmpro-testimonials-submission-settings -->
+
+		<div id="pmpro-testimonials-shortcode-examples" class="pmpro_section" data-visibility="hidden" data-activated="false">
+			<div class="pmpro_section_toggle">
+				<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">
+					<span class="dashicons dashicons-arrow-down-alt2"></span>
+					<?php esc_html_e( 'Shortcode Examples', 'pmpro-testimonials' ); ?>
+				</button>
+			</div> <!-- end pmpro_section_toggle -->
+			<div class="pmpro_section_inside" style="display: none;">
+				<p>
+					<?php esc_html_e( 'Use the following shortcode examples to display testimonials in your membership site.', 'pmpro-testimonials' ); ?>
+					<a href="<?php echo esc_url( 'https://www.paidmembershipspro.com/add-ons/testimonials/?utm_source=plugin&utm_medium=pmpro-testimonials-settings&utm_campaign=pmpro-testimonials' ); ?>" target="_blank"><?php esc_html_e( 'Refer to the documentation for a complete list of shortcode attributes and more examples.', 'pmpro-testimonials' ); ?></a>
+				</p>
+				<table class="form-table">
+					<tr valign="top">
+						<th scope="row"><?php esc_html_e( 'Display Testimonials', 'pmpro-testimonials' ); ?></th>
+						<td>
+							<code>[pmpro_testimonials_display]</code>
+							<p class="description"><?php esc_html_e( 'Displays a list of testimonials or a single testimonial. You can customize the output using shortcode attributes such as "testimonials" (IDs), "categories", "tags", "limit", and more.', 'pmpro-testimonials' ); ?></p>
+						</td>
+					</tr>
+					<tr valign="top">
+						<th scope="row"><?php esc_html_e( 'Testimonial Submission Form', 'pmpro-testimonials' ); ?></th>
+						<td>
+							<code>[pmpro_testimonials_form]</code>
+							<p class="description"><?php esc_html_e( 'Displays a form for users to submit their testimonials. Customize fields and dropdowns using attributes such as "categories", "tags", and "required_fields".', 'pmpro-testimonials' ); ?></p>
+						</td>
+					</tr>
+				</table>
+			</div> <!-- end pmpro_section_inside -->
+		</div> <!-- end pmpro-testimonials-shortcode-examples -->
 
 		<?php wp_nonce_field( 'pmpro_testimonials_settings', 'pmpro_testimonials_settings' ); ?>
 		<?php submit_button(); ?>

--- a/includes/adminpages/settings.php
+++ b/includes/adminpages/settings.php
@@ -23,7 +23,7 @@
 		$testimonial_image_id  = get_option( 'pmpro_testimonials_default_image', '' );
 		$testimonial_image_url = $testimonial_image_id ? wp_get_attachment_url( $testimonial_image_id ) : PMPRO_TESTIMONIALS_URL . 'images/default-user.png';
 		?>
-		<div id="pmpro-testimonials-submission-settings" class="pmpro_section" data-visibility="show" data-activated="true">
+		<div id="pmpro-testimonials-submission-settings" class="pmpro_section" data-visibility="shown" data-activated="true">
 			<div class="pmpro_section_toggle">
 				<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">
 					<span class="dashicons dashicons-arrow-up-alt2"></span>
@@ -84,7 +84,7 @@
 			</div> <!-- end pmpro_section_inside -->
 		</div> <!-- end pmpro-testimonials-submission-settings -->
 
-		<div id="pmpro-testimonials-submission-settings" class="pmpro_section" data-visibility="show" data-activated="true">
+		<div id="pmpro-testimonials-submission-settings" class="pmpro_section" data-visibility="shown" data-activated="true">
 			<div class="pmpro_section_toggle">
 				<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">
 					<span class="dashicons dashicons-arrow-up-alt2"></span>
@@ -121,7 +121,7 @@
 
 		<div id="pmpro-testimonials-shortcode-examples" class="pmpro_section" data-visibility="hidden" data-activated="false">
 			<div class="pmpro_section_toggle">
-				<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">
+				<button class="pmpro_section-toggle-button" type="button" aria-expanded="false">
 					<span class="dashicons dashicons-arrow-down-alt2"></span>
 					<?php esc_html_e( 'Shortcode Examples', 'pmpro-testimonials' ); ?>
 				</button>

--- a/includes/classes/pmpro-testimonial.php
+++ b/includes/classes/pmpro-testimonial.php
@@ -130,7 +130,10 @@ class PMPro_Testimonial {
 			return wp_get_attachment_image( $image_id, $size, false, $attr );
 		}
 
+		// Set up some defaults.
 		$default_image_id = get_option( 'pmpro_testimonials_default_image', '' );
+		$alt   = $this->get_name();
+		$style = ( ! empty( $attr['style'] ) ) ? $attr['style'] : '';
 
 		// If we have an email address, get the user's gravatar.
 		$email = $this->get_email();
@@ -142,8 +145,6 @@ class PMPro_Testimonial {
 			$default_image_url = ! empty( $default_image_src[0] ) ? $default_image_src[0] : PMPRO_TESTIMONIALS_URL . 'images/default-user.png';
 
 			// Build attributes and request the avatar.
-			$alt   = $this->get_name();
-			$style = ( ! empty( $attr['style'] ) ) ? $attr['style'] : '';
 			$gravatar_url = get_avatar_url( $email, array( 'default' => $default_image_url ) );
 			if ( $gravatar_url ) {
 				return '<img src="' . esc_url( $gravatar_url ) . '" alt="' . esc_attr( $alt ) . '" style="' . esc_attr( $style ) . '" />';

--- a/includes/classes/pmpro-testimonial.php
+++ b/includes/classes/pmpro-testimonial.php
@@ -124,33 +124,38 @@ class PMPro_Testimonial {
 	}
 
 	function get_image( $size = 'thumbnail', $attr = '' ) {
-
+		// Use the post's featured image if available.
 		if ( has_post_thumbnail( $this->id ) ) {
 			$image_id = get_post_thumbnail_id( $this->id );
 			return wp_get_attachment_image( $image_id, $size, false, $attr );
 		}
 
-		// Try gravatar as fallback.
-		$email = $this->get_email();
-		$alt   = $this->get_name();
-		$style = ( ! empty( $attr['style'] ) ) ? $attr['style'] : '';
+		$default_image_id = get_option( 'pmpro_testimonials_default_image', '' );
 
-		// Generate Gravatar URL if email is available.
+		// If we have an email address, get the user's gravatar.
+		$email = $this->get_email();
 		if ( $email ) {
-			$gravatar_url = get_avatar_url( strtolower( trim( $email ) ) );
+			$email = strtolower( trim( $email ) );
+
+			// Use the custom or default image as the fallback.
+			$default_image_src = wp_get_attachment_image_src( $default_image_id, 'thumbnail', false );
+			$default_image_url = ! empty( $default_image_src[0] ) ? $default_image_src[0] : PMPRO_TESTIMONIALS_URL . 'images/default-user.png';
+
+			// Build attributes and request the avatar.
+			$alt   = $this->get_name();
+			$style = ( ! empty( $attr['style'] ) ) ? $attr['style'] : '';
+			$gravatar_url = get_avatar_url( $email, array( 'default' => $default_image_url ) );
 			if ( $gravatar_url ) {
-				// Gravatar exists, use it.
 				return '<img src="' . esc_url( $gravatar_url ) . '" alt="' . esc_attr( $alt ) . '" style="' . esc_attr( $style ) . '" />';
 			}
 		}
 
-		// If no Gravatar, look for settings fallback image.
-		$default_image_id = get_option( 'pmpro_testimonials_default_image', '' );
+		// Use the site's default image.
 		if ( $default_image_id ) {
 			return wp_get_attachment_image( $default_image_id, $size, false, $attr );
 		}
 
-		// Our internal fallback image.
+		// Use the plugin's default image.
 		$fallback_image_url = PMPRO_TESTIMONIALS_URL . 'images/default-user.png';
 		return '<img src="' . esc_url( $fallback_image_url ) . '" alt="' . esc_attr( $alt ) . '" style="' . esc_attr( $style ) . '" />';
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-testimonials/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Resolving conflicts where gravatar would not use the site's fallback image.

Added settings screen panel for examples.
