### PR TITLE
Adding schema itemReviewed to head on pages with testimonial shortcod…

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -12,6 +12,16 @@ function pmpro_testimonials_activation() {
 		if ( empty( $confirmation_message ) ) {
 			update_option( 'pmpro_testimonials_confirmation_message', __( 'Thank you for sharing your testimonial. Our team will review your submission.', 'pmpro-testimonials' ) );
 		}
+		$schema_type = get_option( 'pmpro_testimonials_schema_type' );
+		if ( empty( $schema_type ) ) {
+			update_option( 'pmpro_testimonials_schema_type', 'Service' );
+		}
+
+		$schema_description = get_option( 'pmpro_testimonials_schema_description' );
+		if ( empty( $schema_description ) ) {
+			update_option( 'pmpro_testimonials_schema_description', __( 'Access exclusive content and benefits with our memberships.', 'pmpro-testimonials' ) );
+		}
+
 		$star_color = get_option( 'pmpro_testimonials_star_color' );
 		if ( empty( $star_color ) ) {
 			update_option( 'pmpro_testimonials_star_color', '#ffd700' );

--- a/includes/adminpages/settings.php
+++ b/includes/adminpages/settings.php
@@ -1,4 +1,6 @@
 <?php
+	global $msg, $msgt;
+
 	// Make sure PMPro is active.
 	if ( ! defined( 'PMPRO_DIR' ) ) {
 		echo "<p>" . esc_html__( 'Please activate Paid Memberships Pro to use the Testimonials Add On.', 'pmpro-testimonials' ) . "</p>";
@@ -19,6 +21,8 @@
 		$confirmation_type     = get_option( 'pmpro_testimonials_confirmation_type', 'message' );
 		$redirect_page         = get_option( 'pmpro_testimonials_redirect_page', 0 );
 		$confirmation_message  = get_option( 'pmpro_testimonials_confirmation_message', '' );
+		$schema_type           = get_option( 'pmpro_testimonials_schema_type', 'Service' );
+		$schema_description    = get_option( 'pmpro_testimonials_schema_description', '' );
 		$star_color            = empty( get_option( 'pmpro_testimonials_star_color', '#ffd700' ) ) ? '#ffd700' : get_option( 'pmpro_testimonials_star_color', '#ffd700' );
 		$testimonial_image_id  = get_option( 'pmpro_testimonials_default_image', '' );
 		$testimonial_image_url = $testimonial_image_id ? wp_get_attachment_url( $testimonial_image_id ) : PMPRO_TESTIMONIALS_URL . 'images/default-user.png';
@@ -94,6 +98,34 @@
 			</div> <!-- end pmpro_section_toggle -->
 			<div class="pmpro_section_inside">
 				<table class="form-table">
+					<tr valign="top">
+						<th scope="row"><?php esc_html_e( 'Business Type', 'pmpro-testimonials' ); ?></th>
+						<td>
+							<select name="pmpro_testimonials_schema_type" id="pmpro_review_schema_type">
+								<option value="Service" <?php selected( $schema_type, 'Service' ); ?>>
+									<?php esc_html_e( 'Service', 'pmpro-testimonials' ); ?>
+								</option>
+								<option value="Organization" <?php selected( $schema_type, 'Organization' ); ?>>
+									<?php esc_html_e( 'Organization', 'pmpro-testimonials' ); ?>
+								</option>
+								<option value="EducationalOccupationalProgram" <?php selected( $schema_type, 'EducationalOccupationalProgram' ); ?>>
+									<?php esc_html_e( 'Educational/Occupational Program', 'pmpro-testimonials' ); ?>
+								</option>
+								<option value="MediaSubscription" <?php selected( $schema_type, 'MediaSubscription' ); ?>>
+									<?php esc_html_e( 'Media Subscription', 'pmpro-testimonials' ); ?>
+								</option>
+							</select>
+							<p class="description"><?php esc_html_e( 'Select the type of business or service that your testimonials are for.', 'pmpro-testimonials' ); ?></p>
+						</td>
+					</tr>
+
+					<tr valign="top">
+						<th scope="row"><?php esc_html_e( 'Short Description', 'pmpro-testimonials' ); ?></th>
+						<td>
+							<input type="text" name="pmpro_testimonials_schema_description" value="<?php echo esc_attr( $schema_description ); ?>" class="regular-text" />
+							<p class="description"><?php esc_html_e( 'A short description of the business or service that your testimonials are for. If you clear this field, a default system message will be displayed.', 'pmpro-testimonials' ); ?></p>
+						</td>
+					</tr>
 
 					<!-- Color Picker -->
 					<tr valign="top">
@@ -155,7 +187,7 @@
 		<?php submit_button(); ?>
 	</form>
 	<hr />
-	<p><a href="https://www.paidmembershipspro.com/add-ons/pmpro-testimonials/?utm_source=plugin&utm_medium=pmpro-testimonials-admin&utm_campaign=add-ons" target="_blank"><?php esc_html_e( 'Documentation', 'pmpro-testimonials' ); ?></a> | <a href="https://www.paidmembershipspro.com/support/?utm_source=plugin&utm_medium=pmpro-testimonials-admin&utm_campaign=support" target="_blank"><?php esc_html_e( 'Support', 'pmpro-testimonials' ); ?></a></p>
+	<p><a href="https://www.paidmembershipspro.com/add-ons/testimonials/?utm_source=plugin&utm_medium=pmpro-testimonials-admin&utm_campaign=add-ons" target="_blank"><?php esc_html_e( 'Documentation', 'pmpro-testimonials' ); ?></a> | <a href="https://www.paidmembershipspro.com/support/?utm_source=plugin&utm_medium=pmpro-testimonials-admin&utm_campaign=support" target="_blank"><?php esc_html_e( 'Support', 'pmpro-testimonials' ); ?></a></p>
 
 	<script type="text/javascript">
 

--- a/includes/classes/pmpro-testimonial.php
+++ b/includes/classes/pmpro-testimonial.php
@@ -186,8 +186,8 @@ class PMPro_Testimonial {
 	}
 
 	function get_review_schema_name() {
-		// translators: %1$s is the site name, %d is the rating, %3$s is the reviewer name.
 		return sprintf(
+			/* translators: %1$s is the site name, %2$s is the rating, %3$s is the reviewer name. */
 			__( '%1$s Testimonial: %2$s out of 5 stars by %3$s', 'pmpro-testimonials' ),
 			esc_html( bloginfo('name') ),
 			esc_html( $this->get_rating() ),

--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -10,6 +10,7 @@ function pmpro_testimonial_wp_head() {
 		$site_url = get_bloginfo('url');
 		$schema_type = get_option( 'pmpro_testimonials_schema_type', 'Service' );
 		$schema_name = sprintf(
+			/* translators: %s: Site title */
 			__( '%s Membership', 'pmpro-testimonials' ),
 			get_bloginfo( 'name' )
 		);
@@ -17,10 +18,6 @@ function pmpro_testimonial_wp_head() {
 		if ( empty( $schema_description ) ) {
 			$schema_description = __( 'Access exclusive content and benefits with our memberships.', 'pmpro-testimonials' );
 		}
-		$product_description = sprintf(
-			__( 'Testimonials from members of %s', 'pmpro-testimonials' ),
-			get_bloginfo( 'name' )
-		);
 
 		// Output the structured data
 		echo '<script type="application/ld+json">

--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -1,4 +1,45 @@
 <?php
+// Add review schema to site <head>.
+function pmpro_testimonial_wp_head() {
+    global $post;
+
+	// Check if the post content contains the specific shortcodes
+	if ( $post && ( has_shortcode( $post->post_content, 'pmpro_testimonials_display' ) || has_shortcode( $post->post_content, 'pmpro_testimonials_display_custom' ) ) ) {
+		// Get site title and URL
+		$site_title = get_bloginfo('name');
+		$site_url = get_bloginfo('url');
+		$schema_type = get_option( 'pmpro_testimonials_schema_type', 'Service' );
+		$schema_name = sprintf(
+			__( '%s Membership', 'pmpro-testimonials' ),
+			get_bloginfo( 'name' )
+		);
+		$schema_description = get_option( 'pmpro_testimonials_schema_description' );
+		if ( empty( $schema_description ) ) {
+			$schema_description = __( 'Access exclusive content and benefits with our memberships.', 'pmpro-testimonials' );
+		}
+		$product_description = sprintf(
+			__( 'Testimonials from members of %s', 'pmpro-testimonials' ),
+			get_bloginfo( 'name' )
+		);
+
+		// Output the structured data
+		echo '<script type="application/ld+json">
+{
+	"@context": "https://schema.org/",
+	"@type": "' . esc_html( $schema_type ) . '",
+	"name": "' . esc_html( $schema_name ) . '",
+	"description": "' . esc_html( $schema_description ) . '",
+	"provider": {
+		"@type": "Organization",
+		"name": "' . esc_html( $site_title ) . '",
+		"url": "' . esc_url( $site_url ) . '"
+	}
+}
+</script>';
+	}
+}
+add_action( 'wp_head', 'pmpro_testimonial_wp_head' );
+
 // Used for the featured image block.
 function pmpro_testimonial_featured_image_fallback( $html, $post_id, $post_thumbnail_id, $size, $attr ) {
 

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -39,32 +39,27 @@ function pmpro_register_settings() {
 	register_setting( 'pmpro_testimonials_settings', 'pmpro_testimonials_confirmation_type' );
 	register_setting( 'pmpro_testimonials_settings', 'pmpro_testimonials_redirect_page' );
 	register_setting( 'pmpro_testimonials_settings', 'pmpro_testimonials_confirmation_message' );
+	register_setting( 'pmpro_testimonials_settings', 'pmpro_testimonials_schema_type' );
+	register_setting( 'pmpro_testimonials_settings', 'pmpro_testimonials_schema_description' );
 	register_setting( 'pmpro_testimonials_settings', 'pmpro_testimonials_star_color' );
 	register_setting( 'pmpro_testimonials_settings', 'pmpro_testimonials_default_image' );
 }
-
 add_action( 'admin_init', 'pmpro_register_settings' );
 
-function pmpro_testimonials_settings_save() {
-	// Check permissions.
-	if ( ! current_user_can( 'manage_options' ) ) {
-		return;
-	}
-
-	// Check if form is being submitted.
-	if ( ! isset( $_POST['pmpro_testimonials_settings'] ) || ! wp_verify_nonce( $_POST['pmpro_testimonials_settings'], 'pmpro_testimonials_settings' ) ) {
-		return;
-	}
-
-	// Save module specific settings.
-	do_action( 'pmpro_testimonials_settings_save' );
-
-}
-// add_action( 'admin_init', 'pmpro_testimonials_settings_save' );
-
-function pmpro_testimonials_save_notice() {
-	if ( isset( $_REQUEST['pmpro_testimonials_save_settings'] ) ) {
-		echo sprintf( "<div class='updated'><p>%s</p></div>", esc_html__( 'Settings saved successfully.', 'pmpro-testimonials' ) );
+/**
+ * Display a success message after saving settings.
+ */
+function pmpro_testimonials_settings_success_message() {
+	// Check if we are on the Testimonials settings page and if settings were saved.
+	if (
+		isset( $_GET['page'] ) &&
+		'pmpro-testimonials-settings' === $_GET['page'] &&
+		isset( $_GET['settings-updated'] ) &&
+		'true' === $_GET['settings-updated']
+	) {
+		echo '<div class="notice notice-success">';
+		echo '<p>' . esc_html__( 'Settings saved successfully.', 'pmpro-testimonials' ) . '</p>';
+		echo '</div>';
 	}
 }
-// add_action( 'admin_notices', 'pmpro_testimonials_save_notice', 10 );
+add_action( 'admin_notices', 'pmpro_testimonials_settings_success_message' );


### PR DESCRIPTION
…e display; save message

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-testimonials/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Google's Rich Snippet testing tool revealed we were missing the itemReviewed schema. This PR adds a new setting for Schema type and description, which defaults to Service and the description: Access exclusive content and benefits with our memberships.

