### PR TITLE
Remove displayAtCheckout usage

### DIFF
--- a/includes/classes/pmpro-testimonial-display.php
+++ b/includes/classes/pmpro-testimonial-display.php
@@ -153,7 +153,7 @@ class PMPro_Testimonial_Display {
 			return '';
 		}
 
-		$html = '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro pmpro_testimonials pmpro_testimonials__' . $this->layout . ' pmpro_testimonials__' . $this->layout ) ) . '">';
+		$html = '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro pmpro_testimonials pmpro_testimonials__' . $this->layout, ' pmpro_testimonials__' . $this->layout ) ) . '">';
 
 		foreach ( $testimonials as $testimonial ) {
 

--- a/includes/classes/pmpro-testimonial-form.php
+++ b/includes/classes/pmpro-testimonial-form.php
@@ -66,18 +66,6 @@ class PMPro_Testimonial_Form {
 			}
 		}
 
-		// Must be running PMPro to show the form.
-		if ( ! class_exists( 'PMPro_Field' ) ) {
-			$message = '<div id="pmpro_testimonials_error" class="' . esc_attr( pmpro_get_element_class( 'pmpro_message pmpro_error', 'pmpro_testimonials_error' ) ) . '">' . esc_html__( 'Please activate Paid Memberships Pro to use this form.', 'pmpro-testimonials' ) . '</div>';
-
-			if ( $echo ) {
-				echo wp_kses_post( $message );
-				return;
-			} else {
-				return $message;
-			}
-		}
-
 		// Process again to get errors.
 		$this->process();
 

--- a/includes/classes/pmpro-testimonial-form.php
+++ b/includes/classes/pmpro-testimonial-form.php
@@ -249,13 +249,13 @@ class PMPro_Testimonial_Form {
 											$selected_category = isset( $_POST['testimonial_category'] ) ? intval( $_POST['testimonial_category'] ) : '';
 											$classes = array( 'pmpro_form_field', 'pmpro_form_field-select' );
 											$required = false;
-											if ( in_array( 'url', $this->required_fields ) ) {
+											if ( in_array( 'testimonial_category', $this->required_fields ) ) {
 												$required = true;
 												$classes[] = 'pmpro_form_field-required';
 											}
 											?>
 											<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'testimonial_category' ) ); ?>">
-												<label for="url" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+												<label for="testimonial_category" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
 													<?php esc_html_e( 'Category', 'pmpro-testimonials' );?>
 													<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
 												</label>

--- a/includes/classes/pmpro-testimonial-form.php
+++ b/includes/classes/pmpro-testimonial-form.php
@@ -43,6 +43,7 @@ class PMPro_Testimonial_Form {
 	}
 
 	public function display( $echo = true ) {
+		global $current_user;
 
 		// If we are on the success message page, show it and bail.
 		if ( isset( $_GET['testimonial_success'] ) ) {
@@ -98,21 +99,18 @@ class PMPro_Testimonial_Form {
 									<h2 class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_heading pmpro_font-large' ) ); ?>"><?php esc_html_e( 'Submit Your Testimonial', 'pmpro-testimonials' ); ?></h2>
 								</legend>
 								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields' ) ); ?>">
-									<?php
-									// Testimonial field
-									$title_field = new PMPro_Field(
-										'testimonial',
-										'textarea',
-										array(
-											'label'        => __( 'Testimonial', 'pmpro-testimonials' ),
-											'required'     => true,
-											'showrequired' => 'label',
-										)
-									);
-									$title_field->displayAtCheckout();
+									
+									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-textarea', 'testimonial' ) ); ?>">
+										<label for="testimonial" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+											<?php esc_html_e( 'Testimonial', 'paid-memberships-pro' );?>
+											<span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span>
+										</label>
+										<textarea name="testimonial" rows="5" cols="80" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-textarea', 'testimonial' ) ); ?>"><?php echo ( ( ! empty( $_POST['testimonial'] ) ) ? esc_textarea(wp_unslash($_POST['testimonial']) ) : '' );?></textarea>
+									</div>
 
+									<?php
 									// Rating field (Star Rating would still require custom JavaScript)
-									echo '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required' ) ) . '">';
+									echo '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-rating' ) ) . '">';
 									echo '<label class="' . esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ) . '" for="rating">' . esc_html__( 'Rating', 'pmpro-testimonials' ) . ' <span class="' . esc_attr( pmpro_get_element_class( 'pmpro_asterisk' ) ) . '"> <abbr title="' . esc_html__( 'Required Field', 'pmpro-testimonials' ) . '">*</abbr></span></label>';
 									echo '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro_star_rating' ) ) . '">';
 									$rating_value = isset( $_POST['rating'] ) ? intval( $_POST['rating'] ) : 0;
@@ -128,113 +126,160 @@ class PMPro_Testimonial_Form {
 									echo '</div>';
 									echo '<input type="hidden" name="rating" value="' . esc_attr( $rating_value ) . '">';
 									echo '</div>';
+									?>
 
-									// Name field.
-									$name_field = new PMPro_Field(
-										'display_name',
-										'text',
-										array(
-											'label'        => __( 'Name', 'pmpro-testimonials' ),
-											'required'     => true,
-											'showrequired' => 'label',
-										)
-									);
-									$name_field->displayAtCheckout();
+									<?php
+									$value = '';
+									if ( ! empty( $_POST['display_name'] ) ) {
+										$value = wp_unslash( $_POST['display_name'] );
+									} elseif ( is_user_logged_in() ) {
+										$value = $current_user->display_name;
+									}
+									?>
+									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-text', 'display_name' ) ); ?>">
+										<label for="display_name" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+											<?php esc_html_e( 'Name', 'paid-memberships-pro' );?>
+											<span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span>
+										</label>
+										<input type="text" name="display_name" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'display_name' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+									</div>
 
-									// Job Title field.
-									$job_title_field = new PMPro_Field(
-										'job_title',
-										'text',
-										array(
-											'label'        => __( 'Job Title', 'pmpro-testimonials' ),
-											'required'     => in_array( 'job_title', $this->required_fields ),
-											'showrequired' => 'label',
-										)
-									);
-									$job_title_field->displayAtCheckout();
+									<?php
+									$value = '';
+									if ( ! empty( $_POST['job_title'] ) ) {
+										$value = wp_unslash( $_POST['job_title'] );
+									}
+									$required = false;
+									if ( in_array( 'job_title', $this->required_fields ) ) {
+										$required = true;
+									}
+									?>
+									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-text', 'job_title' ) ); ?>">
+										<label for="job_title" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+											<?php esc_html_e( 'Job Title', 'paid-memberships-pro' );?>
+											<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
+										</label>
+										<input type="text" name="job_title" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'job_title' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+									</div>
 
-									// Company field.
-									$company_field = new PMPro_Field(
-										'company',
-										'text',
-										array(
-											'label'        => __( 'Company', 'pmpro-testimonials' ),
-											'required'     => in_array( 'company', $this->required_fields ),
-											'showrequired' => 'label',
-										)
-									);
-									$company_field->displayAtCheckout();
+									<?php
+									$value = '';
+									if ( ! empty( $_POST['company'] ) ) {
+										$value = wp_unslash( $_POST['company'] );
+									}
+									$required = false;
+									if ( in_array( 'company', $this->required_fields ) ) {
+										$required = true;
+									}
+									?>
+									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-text', 'company' ) ); ?>">
+										<label for="company" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+											<?php esc_html_e( 'Company', 'paid-memberships-pro' );?>
+											<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
+										</label>
+										<input type="text" name="company" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'company' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+									</div>
 
-									// Email field.
-									$email_field = new PMPro_Field(
-										'user_email',
-										'text',
-										array(
-											'label'        => __( 'Email', 'pmpro-testimonials' ),
-											'required'     => in_array( 'email', $this->required_fields ),
-											'showrequired' => 'label',
-										)
-									);
-									$email_field->displayAtCheckout();
+									<?php
+									$value = '';
+									if ( ! empty( $_POST['user_email'] ) ) {
+										$value = wp_unslash( $_POST['user_email'] );
+									} elseif ( is_user_logged_in() ) {
+										$value = $current_user->user_email;
+									}
+									$required = false;
+									if ( in_array( 'email', $this->required_fields ) ) {
+										$required = true;
+									}
+									$pmpro_email_field_type = apply_filters( 'pmpro_email_field_type', true );
+									?>
+									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-email', 'email' ) ); ?>">
+										<label for="user_email" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+											<?php esc_html_e( 'Email', 'paid-memberships-pro' );?>
+											<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
+										</label>
+										<input type="<?php echo ( $pmpro_email_field_type ? 'email' : 'text' ); ?>" name="user_email" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-email', 'email' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+									</div>
 
-									// URL field.
-									$url_field = new PMPro_Field(
-										'url',
-										'text',
-										array(
-											'label'        => __( 'URL', 'pmpro-testimonials' ),
-											'required'     => in_array( 'url', $this->required_fields ),
-											'showrequired' => 'label',
-										)
-									);
-									$url_field->displayAtCheckout();
+									<?php
+									$value = '';
+									if ( ! empty( $_POST['url'] ) ) {
+										$value = wp_unslash( $_POST['url'] );
+									}
+									$required = false;
+									if ( in_array( 'url', $this->required_fields ) ) {
+										$required = true;
+									}
+									?>
+									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-text', 'url' ) ); ?>">
+										<label for="url" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+											<?php esc_html_e( 'URL', 'paid-memberships-pro' );?>
+											<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
+										</label>
+										<input type="url" name="url" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'url' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+									</div>
+
+									<?php
 
 									// Category Dropdown (if enabled).
 									if ( filter_var( $this->category_dropdown, FILTER_VALIDATE_BOOLEAN ) ) {
-										$selected_category = isset( $_POST['testimonial_category'] ) ? intval( $_POST['testimonial_category'] ) : '';
-										$category_field    = new PMPro_Field(
-											'testimonial_category',
-											'select',
+										$categories = get_terms(
 											array(
-												'label'   => __( 'Category', 'pmpro-testimonials' ),
-												'options' => wp_list_pluck(
-													get_terms(
-														array(
-															'taxonomy' => 'pmpro_testimonial_category',
-															'hide_empty' => false,
-														)
-													),
-													'name',
-													'term_id'
-												),
-												'default' => $selected_category,
+												'taxonomy' => 'pmpro_testimonial_category',
+												'hide_empty' => false,
 											)
 										);
-										$category_field->displayAtCheckout();
+										if ( $categories ) {
+											$selected_category = isset( $_POST['testimonial_category'] ) ? intval( $_POST['testimonial_category'] ) : '';
+											$required = false;
+											if ( in_array( 'url', $this->required_fields ) ) {
+												$required = true;
+											}
+											?>
+											<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-select', 'url' ) ); ?>">
+												<label for="url" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+													<?php esc_html_e( 'Category', 'paid-memberships-pro' );?>
+													<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
+												</label>
+												<select name="testimonial_category" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select', 'url' ) ); ?>">
+													<?php foreach ( $categories as $category ) { ?>
+														<option value="<?php echo esc_attr( $category->term_id ); ?>" <?php selected( $selected_category, $category->term_id ); ?>><?php echo esc_html( $category->name ); ?></option>
+													<?php } ?>
+												</select>
+											</div>
+											<?php
+										}
 									}
 
 									// Tag Dropdown (if enabled, allows multiple selection).
 									if ( filter_var( $this->tag_dropdown, FILTER_VALIDATE_BOOLEAN ) ) {
-										$selected_tags = isset( $_POST['testimonial_tags'] ) ? array_map( 'intval', $_POST['testimonial_tags'] ) : array();
-										$tag_field     = new PMPro_Field(
-											'testimonial_tags',
-											'select2',
+										$tags = get_terms(
 											array(
-												'label'   => __( 'Tags', 'pmpro-testimonials' ),
-												'options' => wp_list_pluck(
-													get_terms(
-														array(
-															'taxonomy' => 'pmpro_testimonial_tag',
-															'hide_empty' => false,
-														)
-													),
-													'name',
-													'term_id'
-												),
-												'default' => $selected_tags,
+												'taxonomy' => 'pmpro_testimonial_tag',
+												'hide_empty' => false,
 											)
 										);
-										$tag_field->displayAtCheckout();
+										if ( $tags ) {
+											$selected_tags = isset( $_POST['testimonial_tags'] ) ? (array) $_POST['testimonial_tags'] : array();
+											$required = false;
+											if ( in_array( 'tags', $this->required_fields ) ) {
+												$required = true;
+											}
+											?>
+											<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-select', 'testimonial_tag' ) ); ?>">
+												<label for="url" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+													<?php esc_html_e( 'Tags', 'paid-memberships-pro' );?>
+													<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
+												</label>
+												<select id="testimonial_tags" name="testimonial_tags[]" multiple="multiple" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select', 'testimonial_tag' ) ); ?>" style="width: 100%;">
+													<?php foreach ( $tags as $tag ) { ?>
+														<option value="<?php echo esc_attr( $tag->term_id ); ?>" <?php selected( in_array( $tag->term_id, $selected_tags ), true ); ?>><?php echo esc_html( $tag->name ); ?></option>
+													<?php } ?>
+												</select>
+												<script>jQuery(document).ready(function($){ $( '#testimonial_tags' ).select2({ theme: "classic", width: "resolve" }); });</script>
+											</div>
+											<?php
+										}
 									}
 									?>
 	
@@ -322,7 +367,7 @@ class PMPro_Testimonial_Form {
 				$job_title   = sanitize_text_field( $_POST['job_title'] );
 				$company     = sanitize_text_field( $_POST['company'] );
 				$email       = sanitize_email( $_POST['user_email'] );
-				$url         = esc_url_raw( $_POST['url'] );
+				$url         = sanitize_url( $_POST['url'] );
 				$rating      = intval( $_POST['rating'] );
 
 				$categories = array();
@@ -339,7 +384,7 @@ class PMPro_Testimonial_Form {
 					$tags_string = sanitize_text_field( $_POST['tags'] );
 					$tags = array_map( 'trim', explode( ',', $tags_string ) );
 				}
-				if ( isset( $_POST['testimonial_tags'] ) && is_array( $_POST['testimonial_tags'] ) ) {
+				if ( ! empty( $_POST['testimonial_tags'] ) && is_array( $_POST['testimonial_tags'] ) ) {
 					$tags = array_merge( $tags, array_map( 'intval', $_POST['testimonial_tags'] ) );
 				}
 

--- a/includes/classes/pmpro-testimonial-form.php
+++ b/includes/classes/pmpro-testimonial-form.php
@@ -357,7 +357,7 @@ class PMPro_Testimonial_Form {
 			if ( empty( $_POST['rating'] ) ) {
 				$error_fields[] = esc_html__( 'Rating', 'pmpro-testimonials' );
 			}
-			if ( in_array( 'name', $this->required_fields ) && empty( $_POST['display_name'] ) ) {
+			if ( empty( $_POST['display_name'] ) ) {
 				$error_fields[] = esc_html__( 'Name', 'pmpro-testimonials' );
 			}
 			if ( in_array( 'email', $this->required_fields ) && empty( $_POST['email'] ) ) {

--- a/includes/classes/pmpro-testimonial-form.php
+++ b/includes/classes/pmpro-testimonial-form.php
@@ -55,7 +55,7 @@ class PMPro_Testimonial_Form {
 			}
 
 			// Wrap it in PMPro classes for styling.
-			$message = '<div id="pmpro_testimonials_success" class="' . esc_attr( pmpro_get_element_class( 'pmpro_message pmpro_success' ) ) . '">' . $message . '</div>';
+			$message = '<div id="pmpro_testimonials_success" class="' . esc_attr( pmpro_get_element_class( 'pmpro_message pmpro_success', 'pmpro_testimonials_success' ) ) . '">' . $message . '</div>';
 
 			// Show or return the message.
 			if ( $echo ) {
@@ -92,7 +92,7 @@ class PMPro_Testimonial_Form {
 						<div id="pmpro_message" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message pmpro_error', 'pmpro_error' ) ); ?>" role="alert"><?php echo wp_kses_post( join( '<br>', $this->errors ) ); ?></div>
 					<?php } ?>
 
-					<fieldset id="pmpro_testimonials_submission" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fieldset' ) ); ?>">
+					<fieldset id="pmpro_testimonials_submission" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fieldset', 'pmpro_testimonials_submission' ) ); ?>">
 						<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card' ) ); ?>">
 							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
 								<legend class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_legend' ) ); ?>">
@@ -100,7 +100,7 @@ class PMPro_Testimonial_Form {
 								</legend>
 								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields' ) ); ?>">
 									
-									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-textarea', 'testimonial' ) ); ?>">
+									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-textarea pmpro_form_field-testimonial', 'pmpro_form_field-testimonial' ) ); ?>">
 										<label for="testimonial" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
 											<?php esc_html_e( 'Testimonial', 'pmpro-testimonials' );?>
 											<span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span>
@@ -110,7 +110,7 @@ class PMPro_Testimonial_Form {
 
 									<?php
 									// Rating field (Star Rating would still require custom JavaScript)
-									echo '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-rating' ) ) . '">';
+									echo '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-rating', 'pmpro_form_field-rating' ) ) . '">';
 									echo '<label class="' . esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ) . '" for="rating">' . esc_html__( 'Rating', 'pmpro-testimonials' ) . ' <span class="' . esc_attr( pmpro_get_element_class( 'pmpro_asterisk' ) ) . '"> <abbr title="' . esc_html__( 'Required Field', 'pmpro-testimonials' ) . '">*</abbr></span></label>';
 									echo '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro_star_rating' ) ) . '" role="radiogroup" aria-labelledby="rating">';
 									$rating_value = isset( $_POST['rating'] ) ? intval( $_POST['rating'] ) : 0;
@@ -127,7 +127,7 @@ class PMPro_Testimonial_Form {
 										}
 										$class = join( ' ', $classes );
 										$label = sprintf( esc_html__( '%s Star Rating', 'pmpro-testimonials' ), $i );
-										echo '<svg role="radio" aria-checked="' . esc_attr( $checked ) . '" aria-label="' . esc_attr( $label ) . '" data-value="' . esc_attr( $i ) . '" class="' . esc_attr( $class ) . '" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+										echo '<svg role="radio" aria-checked="' . esc_attr( $checked ) . '" aria-label="' . esc_attr( $label ) . '" data-value="' . esc_attr( $i ) . '" class="' . esc_attr( pmpro_get_element_class( $class, 'pmpro_star' ) ) . '" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
 											<polygon points="12 17.27 18.18 21 16.54 13.97 22 9.24 14.81 8.63 12 2 9.19 8.63 2 9.24 7.46 13.97 5.82 21 12 17.27" />
 										</svg>';
 									}
@@ -177,14 +177,14 @@ class PMPro_Testimonial_Form {
 									if ( ! empty( $_POST['company'] ) ) {
 										$value = wp_unslash( $_POST['company'] );
 									}
-									$classes = array( 'pmpro_form_field', 'pmpro_form_field-text' );
+									$classes = array( 'pmpro_form_field', 'pmpro_form_field-text', 'pmpro_form_field-company' );
 									$required = false;
 									if ( in_array( 'company', $this->required_fields ) ) {
 										$required = true;
 										$classes[] = 'pmpro_form_field-required';
 									}
 									?>
-									<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'company' ) ); ?>">
+									<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'pmpro_form_field-company' ) ); ?>">
 										<label for="company" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
 											<?php esc_html_e( 'Company', 'pmpro-testimonials' );?>
 											<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
@@ -207,12 +207,12 @@ class PMPro_Testimonial_Form {
 									}
 									$pmpro_email_field_type = apply_filters( 'pmpro_email_field_type', true );
 									?>
-									<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'email' ) ); ?>">
-										<label for="user_email" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+									<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'pmpro_form_field-email' ) ); ?>">
+										<label for="user_email" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label', 'user_email' ) ); ?>">
 											<?php esc_html_e( 'Email', 'pmpro-testimonials' );?>
 											<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
 										</label>
-										<input id="user_email" type="<?php echo ( $pmpro_email_field_type ? 'email' : 'text' ); ?>" name="user_email" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-email', 'email' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+										<input id="user_email" type="<?php echo ( $pmpro_email_field_type ? 'email' : 'text' ); ?>" name="user_email" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-email', 'user_email' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
 									</div>
 
 									<?php
@@ -220,14 +220,14 @@ class PMPro_Testimonial_Form {
 									if ( ! empty( $_POST['url'] ) ) {
 										$value = wp_unslash( $_POST['url'] );
 									}
-									$classes = array( 'pmpro_form_field', 'pmpro_form_field-text' );
+									$classes = array( 'pmpro_form_field', 'pmpro_form_field-text', 'pmpro_form_field-url' );
 									$required = false;
 									if ( in_array( 'url', $this->required_fields ) ) {
 										$required = true;
 										$classes[] = 'pmpro_form_field-required';
 									}
 									?>
-									<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'url' ) ); ?>">
+									<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'pmpro_form_field-url' ) ); ?>">
 										<label for="url" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
 											<?php esc_html_e( 'URL', 'pmpro-testimonials' );?>
 											<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
@@ -247,14 +247,14 @@ class PMPro_Testimonial_Form {
 										);
 										if ( $categories ) {
 											$selected_category = isset( $_POST['testimonial_category'] ) ? intval( $_POST['testimonial_category'] ) : '';
-											$classes = array( 'pmpro_form_field', 'pmpro_form_field-select' );
+											$classes = array( 'pmpro_form_field', 'pmpro_form_field-select', 'pmpro_form_field-testimonial_category' );
 											$required = false;
 											if ( in_array( 'testimonial_category', $this->required_fields ) ) {
 												$required = true;
 												$classes[] = 'pmpro_form_field-required';
 											}
 											?>
-											<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'testimonial_category' ) ); ?>">
+											<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'pmpro_form_field-testimonial_category' ) ); ?>">
 												<label for="testimonial_category" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
 													<?php esc_html_e( 'Category', 'pmpro-testimonials' );?>
 													<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
@@ -279,19 +279,19 @@ class PMPro_Testimonial_Form {
 										);
 										if ( $tags ) {
 											$selected_tags = isset( $_POST['testimonial_tags'] ) ? (array) $_POST['testimonial_tags'] : array();
-											$classes = array( 'pmpro_form_field', 'pmpro_form_field-select' );
+											$classes = array( 'pmpro_form_field', 'pmpro_form_field-select', 'pmpro_form_field-testimonial_tags' );
 											$required = false;
 											if ( in_array( 'tags', $this->required_fields ) ) {
 												$required = true;
 												$classes[] = 'pmpro_form_field-required';
 											}
 											?>
-											<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'testimonial_tag' ) ); ?>">
+											<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'pmpro_form_field-testimonial_tags' ) ); ?>">
 												<label for="url" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
 													<?php esc_html_e( 'Tags', 'pmpro-testimonials' );?>
 													<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
 												</label>
-												<select id="testimonial_tags" name="testimonial_tags[]" multiple="multiple" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select', 'testimonial_tag' ) ); ?>" style="width: 100%;">
+												<select id="testimonial_tags" name="testimonial_tags[]" multiple="multiple" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select', 'testimonial_tags' ) ); ?>" style="width: 100%;">
 													<?php foreach ( $tags as $tag ) { ?>
 														<option value="<?php echo esc_attr( $tag->term_id ); ?>" <?php selected( in_array( $tag->term_id, $selected_tags ), true ); ?>><?php echo esc_html( $tag->name ); ?></option>
 													<?php } ?>
@@ -310,9 +310,9 @@ class PMPro_Testimonial_Form {
 	
 					<div style="position: absolute; left: -99999px;"><input type="text" name="first_name" /></div>
 	
-					<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_submit' ) ); ?>">
+					<div id="pmpro_form_submit-testimonials" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_submit', 'pmpro_form_submit-testimonials' ) ); ?>">
 						<?php wp_nonce_field( 'pmpro_testimonials_form', 'pmpro_testimonials_nonce' ); ?>
-						<input type="submit" name="submit" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit', 'pmpro_btn-submit' ) ); ?>" value="<?php esc_attr_e( 'Submit', 'pmpro-testimonials' ); ?>" />
+						<input type="submit" id="pmpro_btn-submit-testimonials" name="submit" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit', 'pmpro_btn-submit-testimonials' ) ); ?>" value="<?php esc_attr_e( 'Submit', 'pmpro-testimonials' ); ?>" />
 					</div>
 
 					<?php if ( ! empty( $this->categories ) ) {

--- a/includes/classes/pmpro-testimonial-form.php
+++ b/includes/classes/pmpro-testimonial-form.php
@@ -88,7 +88,7 @@ class PMPro_Testimonial_Form {
 								</legend>
 								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields' ) ); ?>">
 									
-									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-textarea pmpro_form_field-testimonial', 'pmpro_form_field-testimonial' ) ); ?>">
+									<div id="testimonial_div" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-textarea pmpro_form_field-testimonial', 'testimonial_div' ) ); ?>">
 										<label for="testimonial" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
 											<?php esc_html_e( 'Testimonial', 'pmpro-testimonials' );?>
 											<span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span>
@@ -98,7 +98,7 @@ class PMPro_Testimonial_Form {
 
 									<?php
 									// Rating field (Star Rating would still require custom JavaScript)
-									echo '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-rating', 'pmpro_form_field-rating' ) ) . '">';
+									echo '<div id="rating_div" class="' . esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-rating', 'rating_div' ) ) . '">';
 									echo '<label class="' . esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ) . '" for="rating">' . esc_html__( 'Rating', 'pmpro-testimonials' ) . ' <span class="' . esc_attr( pmpro_get_element_class( 'pmpro_asterisk' ) ) . '"> <abbr title="' . esc_html__( 'Required Field', 'pmpro-testimonials' ) . '">*</abbr></span></label>';
 									echo '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro_star_rating' ) ) . '" role="radiogroup" aria-labelledby="rating">';
 									$rating_value = isset( $_POST['rating'] ) ? intval( $_POST['rating'] ) : 0;
@@ -132,12 +132,12 @@ class PMPro_Testimonial_Form {
 										$value = $current_user->display_name;
 									}
 									?>
-									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-text', 'display_name' ) ); ?>">
+									<div id="display_name_div" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-text pmpro_form_field-display_name', 'display_name_div' ) ); ?>">
 										<label for="display_name" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
 											<?php esc_html_e( 'Name', 'pmpro-testimonials' );?>
 											<span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span>
 										</label>
-										<input id="display_name" type="text" name="display_name" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'display_name' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+										<input id="display_name" type="text" name="display_name" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-required pmpro_form_input-text', 'display_name' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
 									</div>
 
 									<?php
@@ -145,19 +145,21 @@ class PMPro_Testimonial_Form {
 									if ( ! empty( $_POST['job_title'] ) ) {
 										$value = wp_unslash( $_POST['job_title'] );
 									}
-									$classes = array( 'pmpro_form_field', 'pmpro_form_field-text' );
+									$div_classes = array( 'pmpro_form_field', 'pmpro_form_field-text', 'pmpro_form_field_job_title' );
+									$input_classes = array( 'pmpro_form_input', 'pmpro_form_input-text' );
 									$required = false;
 									if ( in_array( 'job_title', $this->required_fields ) ) {
 										$required = true;
-										$classes[] = 'pmpro_form_field-required';
+										$div_classes[] = 'pmpro_form_field-required';
+										$input_classes[] = 'pmpro_form_input-required';
 									}
 									?>
-									<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'job_title' ) ); ?>">
+									<div id="job_title_div" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $div_classes ), 'job_title_div' ) ); ?>">
 										<label for="job_title" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
 											<?php esc_html_e( 'Job Title', 'pmpro-testimonials' );?>
 											<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
 										</label>
-										<input id="job_title" type="text" name="job_title" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'job_title' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+										<input id="job_title" type="text" name="job_title" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $input_classes ), 'job_title' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
 									</div>
 
 									<?php
@@ -165,19 +167,21 @@ class PMPro_Testimonial_Form {
 									if ( ! empty( $_POST['company'] ) ) {
 										$value = wp_unslash( $_POST['company'] );
 									}
-									$classes = array( 'pmpro_form_field', 'pmpro_form_field-text', 'pmpro_form_field-company' );
+									$div_classes = array( 'pmpro_form_field', 'pmpro_form_field-text', 'pmpro_form_field_company' );
+									$input_classes = array( 'pmpro_form_input', 'pmpro_form_input-text' );
 									$required = false;
 									if ( in_array( 'company', $this->required_fields ) ) {
 										$required = true;
-										$classes[] = 'pmpro_form_field-required';
+										$div_classes[] = 'pmpro_form_field-required';
+										$input_classes[] = 'pmpro_form_input-required';
 									}
 									?>
-									<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'pmpro_form_field-company' ) ); ?>">
+									<div id="company_div" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $div_classes ), 'company_div' ) ); ?>">
 										<label for="company" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
 											<?php esc_html_e( 'Company', 'pmpro-testimonials' );?>
 											<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
 										</label>
-										<input id="company" type="text" name="company" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'company' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+										<input id="company" type="text" name="company" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $input_classes ), 'company' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
 									</div>
 
 									<?php
@@ -187,20 +191,25 @@ class PMPro_Testimonial_Form {
 									} elseif ( is_user_logged_in() ) {
 										$value = $current_user->user_email;
 									}
-									$classes = array( 'pmpro_form_field', 'pmpro_form_field-email' );
+
+									$div_classes = array( 'pmpro_form_field', 'pmpro_form_field-user_email' );
+									$input_classes = array( 'pmpro_form_input' );
 									$required = false;
 									if ( in_array( 'email', $this->required_fields ) ) {
 										$required = true;
-										$classes[] = 'pmpro_form_field-required';
+										$div_classes[] = 'pmpro_form_field-required';
+										$input_classes[] = 'pmpro_form_input-required';
 									}
 									$pmpro_email_field_type = apply_filters( 'pmpro_email_field_type', true );
+									$div_classes[] = $pmpro_email_field_type ? 'pmpro_form_field-email' : 'pmpro_form_field-text';
+									$input_classes[] = $pmpro_email_field_type ? 'pmpro_form_input-email' : 'pmpro_form_input-text';
 									?>
-									<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'pmpro_form_field-email' ) ); ?>">
-										<label for="user_email" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label', 'user_email' ) ); ?>">
+									<div id="user_email_div" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $div_classes ), 'user_email_div' ) ); ?>">
+										<label for="user_email" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
 											<?php esc_html_e( 'Email', 'pmpro-testimonials' );?>
 											<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
 										</label>
-										<input id="user_email" type="<?php echo ( $pmpro_email_field_type ? 'email' : 'text' ); ?>" name="user_email" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-email', 'user_email' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+										<input id="user_email" type="<?php echo ( $pmpro_email_field_type ? 'email' : 'text' ); ?>" name="user_email" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $input_classes ), 'user_email' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
 									</div>
 
 									<?php
@@ -208,19 +217,21 @@ class PMPro_Testimonial_Form {
 									if ( ! empty( $_POST['url'] ) ) {
 										$value = wp_unslash( $_POST['url'] );
 									}
-									$classes = array( 'pmpro_form_field', 'pmpro_form_field-text', 'pmpro_form_field-url' );
+									$div_classes = array( 'pmpro_form_field', 'pmpro_form_field-text', 'pmpro_form_field-url' );
+									$input_classes = array( 'pmpro_form_input', 'pmpro_form_input-text' );
 									$required = false;
 									if ( in_array( 'url', $this->required_fields ) ) {
 										$required = true;
-										$classes[] = 'pmpro_form_field-required';
+										$div_classes[] = 'pmpro_form_field-required';
+										$input_classes[] = 'pmpro_form_input-required';
 									}
 									?>
-									<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'pmpro_form_field-url' ) ); ?>">
+									<div id="url_div" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $div_classes ), 'url_div' ) ); ?>">
 										<label for="url" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
 											<?php esc_html_e( 'URL', 'pmpro-testimonials' );?>
 											<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
 										</label>
-										<input id="url" type="url" name="url" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'url' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+										<input id="url" type="url" name="url" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $input_classes ), 'url' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
 									</div>
 
 									<?php
@@ -235,19 +246,21 @@ class PMPro_Testimonial_Form {
 										);
 										if ( $categories ) {
 											$selected_category = isset( $_POST['testimonial_category'] ) ? intval( $_POST['testimonial_category'] ) : '';
-											$classes = array( 'pmpro_form_field', 'pmpro_form_field-select', 'pmpro_form_field-testimonial_category' );
+											$div_classes = array( 'pmpro_form_field', 'pmpro_form_field-select', 'pmpro_form_field-testimonial_category' );
+											$input_classes = array( 'pmpro_form_input', 'pmpro_form_input-select' );
 											$required = false;
 											if ( in_array( 'testimonial_category', $this->required_fields ) ) {
 												$required = true;
-												$classes[] = 'pmpro_form_field-required';
+												$div_classes[] = 'pmpro_form_field-required';
+												$input_classes[] = 'pmpro_form_input-required';
 											}
 											?>
-											<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'pmpro_form_field-testimonial_category' ) ); ?>">
+											<div id="testimonial_category_div" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $div_classes ), 'testimonial_category_div' ) ); ?>">
 												<label for="testimonial_category" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
 													<?php esc_html_e( 'Category', 'pmpro-testimonials' );?>
 													<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
 												</label>
-												<select id="testimonial_category" name="testimonial_category" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select', 'testimonial_category' ) ); ?>">
+												<select id="testimonial_category" name="testimonial_category" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $input_classes ), 'testimonial_category' ) ); ?>" style="width: 100%;">
 													<?php foreach ( $categories as $category ) { ?>
 														<option value="<?php echo esc_attr( $category->term_id ); ?>" <?php selected( $selected_category, $category->term_id ); ?>><?php echo esc_html( $category->name ); ?></option>
 													<?php } ?>
@@ -267,19 +280,21 @@ class PMPro_Testimonial_Form {
 										);
 										if ( $tags ) {
 											$selected_tags = isset( $_POST['testimonial_tags'] ) ? (array) $_POST['testimonial_tags'] : array();
-											$classes = array( 'pmpro_form_field', 'pmpro_form_field-select', 'pmpro_form_field-testimonial_tags' );
+											$div_classes = array( 'pmpro_form_field', 'pmpro_form_field-select', 'pmpro_form_field-testimonial_tags' );
+											$input_classes = array( 'pmpro_form_input', 'pmpro_form_input-select' );
 											$required = false;
 											if ( in_array( 'tags', $this->required_fields ) ) {
 												$required = true;
-												$classes[] = 'pmpro_form_field-required';
+												$div_classes[] = 'pmpro_form_field-required';
+												$input_classes[] = 'pmpro_form_input-required';
 											}
 											?>
-											<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'pmpro_form_field-testimonial_tags' ) ); ?>">
+											<div id="testimonial_tags_div" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $div_classes ), 'testimonial_tags_div' ) ); ?>">
 												<label for="url" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
 													<?php esc_html_e( 'Tags', 'pmpro-testimonials' );?>
 													<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
 												</label>
-												<select id="testimonial_tags" name="testimonial_tags[]" multiple="multiple" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select', 'testimonial_tags' ) ); ?>" style="width: 100%;">
+												<select id="testimonial_tags" name="testimonial_tags[]" multiple="multiple" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $input_classes ), 'testimonial_tags' ) ); ?>" style="width: 100%;">
 													<?php foreach ( $tags as $tag ) { ?>
 														<option value="<?php echo esc_attr( $tag->term_id ); ?>" <?php selected( in_array( $tag->term_id, $selected_tags ), true ); ?>><?php echo esc_html( $tag->name ); ?></option>
 													<?php } ?>
@@ -298,7 +313,7 @@ class PMPro_Testimonial_Form {
 	
 					<div style="position: absolute; left: -99999px;"><input type="text" name="first_name" /></div>
 	
-					<div id="pmpro_form_submit-testimonials" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_submit', 'pmpro_form_submit-testimonials' ) ); ?>">
+					<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_submit' ) ); ?>">
 						<?php wp_nonce_field( 'pmpro_testimonials_form', 'pmpro_testimonials_nonce' ); ?>
 						<input type="submit" id="pmpro_btn-submit-testimonials" name="submit" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit', 'pmpro_btn-submit-testimonials' ) ); ?>" value="<?php esc_attr_e( 'Submit', 'pmpro-testimonials' ); ?>" />
 					</div>

--- a/includes/classes/pmpro-testimonial-form.php
+++ b/includes/classes/pmpro-testimonial-form.php
@@ -102,29 +102,37 @@ class PMPro_Testimonial_Form {
 									
 									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-textarea', 'testimonial' ) ); ?>">
 										<label for="testimonial" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
-											<?php esc_html_e( 'Testimonial', 'paid-memberships-pro' );?>
+											<?php esc_html_e( 'Testimonial', 'pmpro-testimonials' );?>
 											<span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span>
 										</label>
-										<textarea name="testimonial" rows="5" cols="80" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-textarea', 'testimonial' ) ); ?>"><?php echo ( ( ! empty( $_POST['testimonial'] ) ) ? esc_textarea(wp_unslash($_POST['testimonial']) ) : '' );?></textarea>
+										<textarea id="testimonial" name="testimonial" rows="5" cols="80" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-textarea', 'testimonial' ) ); ?>"><?php echo ( ( ! empty( $_POST['testimonial'] ) ) ? esc_textarea( wp_unslash( $_POST['testimonial'] ) ) : '' );?></textarea>
 									</div>
 
 									<?php
 									// Rating field (Star Rating would still require custom JavaScript)
 									echo '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-rating' ) ) . '">';
 									echo '<label class="' . esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ) . '" for="rating">' . esc_html__( 'Rating', 'pmpro-testimonials' ) . ' <span class="' . esc_attr( pmpro_get_element_class( 'pmpro_asterisk' ) ) . '"> <abbr title="' . esc_html__( 'Required Field', 'pmpro-testimonials' ) . '">*</abbr></span></label>';
-									echo '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro_star_rating' ) ) . '">';
+									echo '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro_star_rating' ) ) . '" role="radiogroup" aria-labelledby="rating">';
 									$rating_value = isset( $_POST['rating'] ) ? intval( $_POST['rating'] ) : 0;
 									for ( $i = 1; $i <= 5; $i++ ) {
 										// Build the selectors for the star.
 										$classes = array( 'pmpro_star' );
-										$classes[] = ( $i <= $rating_value ) ? 'filled' : ''; // Add 'filled' class if previously selected
+										if ( $i <= $rating_value ) {
+											$classes[] = 'filled';
+										} 
+										if ( $i === $rating_value ) {
+											$checked = 'true';
+										} else {
+											$checked = 'false';
+										}
 										$class = implode( ' ', array_unique( $classes ) );
-										echo '<svg data-value="' . esc_attr( $i ) . '" class="' . esc_attr( $class ) . '" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+										$label = sprintf( esc_html__( '%s Star Rating', 'pmpro-testimonials' ), $i );
+										echo '<svg role="radio" aria-checked="' . esc_attr( $checked ) . '" aria-label="' . esc_attr( $label ) . '" data-value="' . esc_attr( $i ) . '" class="' . esc_attr( $class ) . '" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
 											<polygon points="12 17.27 18.18 21 16.54 13.97 22 9.24 14.81 8.63 12 2 9.19 8.63 2 9.24 7.46 13.97 5.82 21 12 17.27" />
 										</svg>';
 									}
 									echo '</div>';
-									echo '<input type="hidden" name="rating" value="' . esc_attr( $rating_value ) . '">';
+									echo '<input id="rating" type="hidden" name="rating" value="' . esc_attr( $rating_value ) . '">';
 									echo '</div>';
 									?>
 
@@ -138,10 +146,10 @@ class PMPro_Testimonial_Form {
 									?>
 									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-text', 'display_name' ) ); ?>">
 										<label for="display_name" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
-											<?php esc_html_e( 'Name', 'paid-memberships-pro' );?>
+											<?php esc_html_e( 'Name', 'pmpro-testimonials' );?>
 											<span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span>
 										</label>
-										<input type="text" name="display_name" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'display_name' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+										<input id="display_name" type="text" name="display_name" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'display_name' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
 									</div>
 
 									<?php
@@ -149,17 +157,19 @@ class PMPro_Testimonial_Form {
 									if ( ! empty( $_POST['job_title'] ) ) {
 										$value = wp_unslash( $_POST['job_title'] );
 									}
+									$classes = array( 'pmpro_form_field', 'pmpro_form_field-text' );
 									$required = false;
 									if ( in_array( 'job_title', $this->required_fields ) ) {
 										$required = true;
+										$classes[] = 'pmpro_form_field-required';
 									}
 									?>
-									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-text', 'job_title' ) ); ?>">
+									<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'job_title' ) ); ?>">
 										<label for="job_title" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
-											<?php esc_html_e( 'Job Title', 'paid-memberships-pro' );?>
+											<?php esc_html_e( 'Job Title', 'pmpro-testimonials' );?>
 											<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
 										</label>
-										<input type="text" name="job_title" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'job_title' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+										<input id="job_title" type="text" name="job_title" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'job_title' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
 									</div>
 
 									<?php
@@ -167,17 +177,19 @@ class PMPro_Testimonial_Form {
 									if ( ! empty( $_POST['company'] ) ) {
 										$value = wp_unslash( $_POST['company'] );
 									}
+									$classes = array( 'pmpro_form_field', 'pmpro_form_field-text' );
 									$required = false;
 									if ( in_array( 'company', $this->required_fields ) ) {
 										$required = true;
+										$classes[] = 'pmpro_form_field-required';
 									}
 									?>
-									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-text', 'company' ) ); ?>">
+									<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'company' ) ); ?>">
 										<label for="company" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
-											<?php esc_html_e( 'Company', 'paid-memberships-pro' );?>
+											<?php esc_html_e( 'Company', 'pmpro-testimonials' );?>
 											<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
 										</label>
-										<input type="text" name="company" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'company' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+										<input id="company" type="text" name="company" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'company' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
 									</div>
 
 									<?php
@@ -187,18 +199,20 @@ class PMPro_Testimonial_Form {
 									} elseif ( is_user_logged_in() ) {
 										$value = $current_user->user_email;
 									}
+									$classes = array( 'pmpro_form_field', 'pmpro_form_field-email' );
 									$required = false;
 									if ( in_array( 'email', $this->required_fields ) ) {
 										$required = true;
+										$classes[] = 'pmpro_form_field-required';
 									}
 									$pmpro_email_field_type = apply_filters( 'pmpro_email_field_type', true );
 									?>
-									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-email', 'email' ) ); ?>">
+									<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'email' ) ); ?>">
 										<label for="user_email" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
-											<?php esc_html_e( 'Email', 'paid-memberships-pro' );?>
+											<?php esc_html_e( 'Email', 'pmpro-testimonials' );?>
 											<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
 										</label>
-										<input type="<?php echo ( $pmpro_email_field_type ? 'email' : 'text' ); ?>" name="user_email" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-email', 'email' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+										<input id="user_email" type="<?php echo ( $pmpro_email_field_type ? 'email' : 'text' ); ?>" name="user_email" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-email', 'email' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
 									</div>
 
 									<?php
@@ -206,17 +220,19 @@ class PMPro_Testimonial_Form {
 									if ( ! empty( $_POST['url'] ) ) {
 										$value = wp_unslash( $_POST['url'] );
 									}
+									$classes = array( 'pmpro_form_field', 'pmpro_form_field-text' );
 									$required = false;
 									if ( in_array( 'url', $this->required_fields ) ) {
 										$required = true;
+										$classes[] = 'pmpro_form_field-required';
 									}
 									?>
-									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-text', 'url' ) ); ?>">
+									<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'url' ) ); ?>">
 										<label for="url" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
-											<?php esc_html_e( 'URL', 'paid-memberships-pro' );?>
+											<?php esc_html_e( 'URL', 'pmpro-testimonials' );?>
 											<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
 										</label>
-										<input type="url" name="url" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'url' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+										<input id="url" type="url" name="url" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'url' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
 									</div>
 
 									<?php
@@ -231,17 +247,19 @@ class PMPro_Testimonial_Form {
 										);
 										if ( $categories ) {
 											$selected_category = isset( $_POST['testimonial_category'] ) ? intval( $_POST['testimonial_category'] ) : '';
+											$classes = array( 'pmpro_form_field', 'pmpro_form_field-select' );
 											$required = false;
 											if ( in_array( 'url', $this->required_fields ) ) {
 												$required = true;
+												$classes[] = 'pmpro_form_field-required';
 											}
 											?>
-											<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-select', 'url' ) ); ?>">
+											<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'testimonial_category' ) ); ?>">
 												<label for="url" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
-													<?php esc_html_e( 'Category', 'paid-memberships-pro' );?>
+													<?php esc_html_e( 'Category', 'pmpro-testimonials' );?>
 													<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
 												</label>
-												<select name="testimonial_category" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select', 'url' ) ); ?>">
+												<select id="testimonial_category" name="testimonial_category" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select', 'testimonial_category' ) ); ?>">
 													<?php foreach ( $categories as $category ) { ?>
 														<option value="<?php echo esc_attr( $category->term_id ); ?>" <?php selected( $selected_category, $category->term_id ); ?>><?php echo esc_html( $category->name ); ?></option>
 													<?php } ?>
@@ -261,14 +279,16 @@ class PMPro_Testimonial_Form {
 										);
 										if ( $tags ) {
 											$selected_tags = isset( $_POST['testimonial_tags'] ) ? (array) $_POST['testimonial_tags'] : array();
+											$classes = array( 'pmpro_form_field', 'pmpro_form_field-select' );
 											$required = false;
 											if ( in_array( 'tags', $this->required_fields ) ) {
 												$required = true;
+												$classes[] = 'pmpro_form_field-required';
 											}
 											?>
-											<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-required pmpro_form_field-select', 'testimonial_tag' ) ); ?>">
+											<div class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $classes ), 'testimonial_tag' ) ); ?>">
 												<label for="url" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
-													<?php esc_html_e( 'Tags', 'paid-memberships-pro' );?>
+													<?php esc_html_e( 'Tags', 'pmpro-testimonials' );?>
 													<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
 												</label>
 												<select id="testimonial_tags" name="testimonial_tags[]" multiple="multiple" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select', 'testimonial_tag' ) ); ?>" style="width: 100%;">

--- a/includes/classes/pmpro-testimonial-form.php
+++ b/includes/classes/pmpro-testimonial-form.php
@@ -125,7 +125,7 @@ class PMPro_Testimonial_Form {
 										} else {
 											$checked = 'false';
 										}
-										$class = implode( ' ', array_unique( $classes ) );
+										$class = join( ' ', $classes );
 										$label = sprintf( esc_html__( '%s Star Rating', 'pmpro-testimonials' ), $i );
 										echo '<svg role="radio" aria-checked="' . esc_attr( $checked ) . '" aria-label="' . esc_attr( $label ) . '" data-value="' . esc_attr( $i ) . '" class="' . esc_attr( $class ) . '" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
 											<polygon points="12 17.27 18.18 21 16.54 13.97 22 9.24 14.81 8.63 12 2 9.19 8.63 2 9.24 7.46 13.97 5.82 21 12 17.27" />

--- a/includes/post-types/testimonials.php
+++ b/includes/post-types/testimonials.php
@@ -109,7 +109,7 @@ function pmpro_testimonials_meta_box() {
 	$company   = get_post_meta( $post->ID, '_company', true );
 	$email     = get_post_meta( $post->ID, '_email', true );
 	$url       = get_post_meta( $post->ID, '_url', true );
-	$rating    = get_post_meta( $post->ID, '_rating', true );
+	$rating    = intval( get_post_meta( $post->ID, '_rating', true ) );
 	?>
 
 	<table class="form-table">
@@ -154,21 +154,25 @@ function pmpro_testimonials_meta_box() {
 				<td>
 					<div id="pmpro_testimonials_rating" class="pmpro_star_rating" data-rating="<?php echo esc_attr( $rating ); ?>">
 						<input type="hidden" name="rating" value="<?php echo esc_attr( $rating ); ?>" />
-						<svg class="pmpro_star" data-value="1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-							<polygon points="12 17.27 18.18 21 16.54 13.97 22 9.24 14.81 8.63 12 2 9.19 8.63 2 9.24 7.46 13.97 5.82 21 12 17.27" />
-						</svg>
-						<svg class="pmpro_star" data-value="2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-							<polygon points="12 17.27 18.18 21 16.54 13.97 22 9.24 14.81 8.63 12 2 9.19 8.63 2 9.24 7.46 13.97 5.82 21 12 17.27" />
-						</svg>
-						<svg class="pmpro_star" data-value="3" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-							<polygon points="12 17.27 18.18 21 16.54 13.97 22 9.24 14.81 8.63 12 2 9.19 8.63 2 9.24 7.46 13.97 5.82 21 12 17.27" />
-						</svg>
-						<svg class="pmpro_star" data-value="4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-							<polygon points="12 17.27 18.18 21 16.54 13.97 22 9.24 14.81 8.63 12 2 9.19 8.63 2 9.24 7.46 13.97 5.82 21 12 17.27" />
-						</svg>
-						<svg class="pmpro_star" data-value="5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-							<polygon points="12 17.27 18.18 21 16.54 13.97 22 9.24 14.81 8.63 12 2 9.19 8.63 2 9.24 7.46 13.97 5.82 21 12 17.27" />
-						</svg>
+						<?php
+						for ( $i = 1; $i <= 5; $i++ ) {
+							// Build the selectors for the star.
+							$classes = array( 'pmpro_star' );
+							if ( $i <= $rating ) {
+								$classes[] = 'filled';
+							} 
+							if ( $i === $rating ) {
+								$checked = 'true';
+							} else {
+								$checked = 'false';
+							}
+							$class = implode( ' ', array_unique( $classes ) );
+							$label = sprintf( esc_html__( '%s Star Rating', 'pmpro-testimonials' ), $i );
+							echo '<svg role="radio" aria-checked="' . esc_attr( $checked ) . '" aria-label="' . esc_attr( $label ) . '" data-value="' . esc_attr( $i ) . '" class="' . esc_attr( $class ) . '" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+								<polygon points="12 17.27 18.18 21 16.54 13.97 22 9.24 14.81 8.63 12 2 9.19 8.63 2 9.24 7.46 13.97 5.82 21 12 17.27" />
+							</svg>';
+						}
+						?>
 					</div>
 				</td>
 			</tr>

--- a/includes/post-types/testimonials.php
+++ b/includes/post-types/testimonials.php
@@ -166,7 +166,7 @@ function pmpro_testimonials_meta_box() {
 							} else {
 								$checked = 'false';
 							}
-							$class = implode( ' ', array_unique( $classes ) );
+							$class = join( ' ', $classes );
 							$label = sprintf( esc_html__( '%s Star Rating', 'pmpro-testimonials' ), $i );
 							echo '<svg role="radio" aria-checked="' . esc_attr( $checked ) . '" aria-label="' . esc_attr( $label ) . '" data-value="' . esc_attr( $i ) . '" class="' . esc_attr( $class ) . '" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
 								<polygon points="12 17.27 18.18 21 16.54 13.97 22 9.24 14.81 8.63 12 2 9.19 8.63 2 9.24 7.46 13.97 5.82 21 12 17.27" />

--- a/includes/shortcodes/display.php
+++ b/includes/shortcodes/display.php
@@ -1,6 +1,11 @@
 <?php
 // Shortcode for displaying testimonials
 function pmpro_testimonials_shortcode_display( $atts, $content = '' ) {
+	// Return early if PMPro is not active.
+	if ( ! defined( 'PMPRO_VERSION' ) ) {
+		return;
+	}
+
 	// Set default values for categories, tags, etc.
 	$atts = shortcode_atts(
 		array(
@@ -26,6 +31,11 @@ add_shortcode( 'pmpro_testimonials_display', 'pmpro_testimonials_shortcode_displ
 
 // Shortcode for displaying testimonials with sub shortcodes inside for custom layouts.
 function pmpro_testimonials_display_custom( $atts, $content = '' ) {
+	// Return early if PMPro is not active.
+	if ( ! defined( 'PMPRO_VERSION' ) ) {
+		return;
+	}
+
 	// Set default values for categories, tags, etc.
 	$atts = shortcode_atts(
 		array(
@@ -83,6 +93,11 @@ add_shortcode( 'pmpro_testimonials_display_custom', 'pmpro_testimonials_display_
 
 // Individual element shortcodes
 function pmpro_testimonial_rating_shortcode( $atts ) {
+	// Return early if PMPro is not active.
+	if ( ! defined( 'PMPRO_VERSION' ) ) {
+		return;
+	}
+
 	$testimonial = $GLOBALS['current_pmpro_testimonial'];
 	$html        = '<span class="' . esc_attr( pmpro_get_element_class( "pmpro_testimonial__rating" ) ) . '" itemprop="reviewRating" itemscope itemtype="https://schema.org/Rating">';
 	$html       .= esc_html( $testimonial->get_rating() );
@@ -95,6 +110,11 @@ function pmpro_testimonial_rating_shortcode( $atts ) {
 add_shortcode( 'pmpro_testimonial_rating', 'pmpro_testimonial_rating_shortcode' );
 
 function pmpro_testimonial_star_rating_shortcode( $atts ) {
+	// Return early if PMPro is not active.
+	if ( ! defined( 'PMPRO_VERSION' ) ) {
+		return;
+	}
+
 	$testimonial = $GLOBALS['current_pmpro_testimonial'];
 	$html        = '<span class="' . esc_attr( pmpro_get_element_class( "pmpro_testimonial__star_rating" ) ) . '" itemprop="reviewRating" itemscope itemtype="https://schema.org/Rating">';
 	$html       .= $testimonial->get_stars();
@@ -107,36 +127,66 @@ function pmpro_testimonial_star_rating_shortcode( $atts ) {
 add_shortcode( 'pmpro_testimonial_star_rating', 'pmpro_testimonial_star_rating_shortcode' );
 
 function pmpro_testimonial_content_shortcode( $atts ) {
+	// Return early if PMPro is not active.
+	if ( ! defined( 'PMPRO_VERSION' ) ) {
+		return;
+	}
+
 	$testimonial = $GLOBALS['current_pmpro_testimonial'];
 	return '<span class="' . esc_attr( pmpro_get_element_class( "pmpro_testimonial__testimonial" ) ) . '" itemprop="reviewBody">' . $testimonial->get_testimonial() . '</span>';
 }
 add_shortcode( 'pmpro_testimonial_content', 'pmpro_testimonial_content_shortcode' );
 
 function pmpro_testimonial_image_shortcode( $atts ) {
+	// Return early if PMPro is not active.
+	if ( ! defined( 'PMPRO_VERSION' ) ) {
+		return;
+	}
+
 	$testimonial = $GLOBALS['current_pmpro_testimonial'];
 	return '<span class="' . esc_attr( pmpro_get_element_class( "pmpro_testimonial__image pmpro_testimonial__image_thumbnail" ) ) . '">' . $testimonial->get_image() . '</span>';
 }
 add_shortcode( 'pmpro_testimonial_image', 'pmpro_testimonial_image_shortcode' );
 
 function pmpro_testimonial_name_shortcode( $atts ) {
+	// Return early if PMPro is not active.
+	if ( ! defined( 'PMPRO_VERSION' ) ) {
+		return;
+	}
+
 	$testimonial = $GLOBALS['current_pmpro_testimonial'];
 	return '<span class="' . esc_attr( pmpro_get_element_class( "pmpro_testimonial__name" ) ) . '" itemprop="author" itemscope itemtype="https://schema.org/Person"><span itemprop="name">' . esc_html( $testimonial->get_name() ) . '</span></span>';
 }
 add_shortcode( 'pmpro_testimonial_name', 'pmpro_testimonial_name_shortcode' );
 
 function pmpro_testimonial_job_title_shortcode( $atts ) {
+	// Return early if PMPro is not active.
+	if ( ! defined( 'PMPRO_VERSION' ) ) {
+		return;
+	}
+
 	$testimonial = $GLOBALS['current_pmpro_testimonial'];
 	return '<span class="' . esc_attr( pmpro_get_element_class( "pmpro_testimonial__job_title" ) ) . '" itemprop="jobTitle">' . esc_html( $testimonial->get_job_title() ) . '</span>';
 }
 add_shortcode( 'pmpro_testimonial_job_title', 'pmpro_testimonial_job_title_shortcode' );
 
 function pmpro_testimonial_company_shortcode( $atts ) {
+	// Return early if PMPro is not active.
+	if ( ! defined( 'PMPRO_VERSION' ) ) {
+		return;
+	}
+
 	$testimonial = $GLOBALS['current_pmpro_testimonial'];
 	return '<span class="' . esc_attr( pmpro_get_element_class( "pmpro_testimonial__company" ) ) . '" itemprop="affiliation" itemscope itemtype="https://schema.org/Organization"><span itemprop="name">' . esc_html( $testimonial->get_company() ) . '</span></span>';
 }
 add_shortcode( 'pmpro_testimonial_company', 'pmpro_testimonial_company_shortcode' );
 
 function pmpro_testimonial_url_shortcode( $atts ) {
+	// Return early if PMPro is not active.
+	if ( ! defined( 'PMPRO_VERSION' ) ) {
+		return;
+	}
+
 	$testimonial = $GLOBALS['current_pmpro_testimonial'];
 	return '<span class="' . esc_attr( pmpro_get_element_class( "pmpro_testimonial__url" ) ) . '">' . esc_url( $testimonial->get_url() ) . '</span>';
 }

--- a/includes/shortcodes/form.php
+++ b/includes/shortcodes/form.php
@@ -5,6 +5,11 @@
  * @param array $atts Shortcode attributes for categories, tags, required fields, and dropdown display.
  */
 function pmpro_testimonials_shortcode_form( $atts ) {
+	// Return early if PMPro is not active.
+	if ( ! defined( 'PMPRO_VERSION' ) ) {
+		return;
+	}
+
 	// Set default values for categories, tags, required fields, and dropdown display.
 	$atts = shortcode_atts(
 		array(

--- a/pmpro-testimonials.php
+++ b/pmpro-testimonials.php
@@ -61,6 +61,12 @@ add_action( 'admin_enqueue_scripts', 'pmpro_testimonials_admin_enqueue' );
  */
 function pmpro_testimonials_frontend_enqueue() {
 	global $post;
+
+	// Return early if PMPro is not active.
+	if ( ! defined( 'PMPRO_URL' ) ) {
+		return;
+	}
+
 	if ( $post && has_shortcode( $post->post_content, 'pmpro_testimonials_form' ) ) {
 		pmpro_testimonials_enqueue_stars();
 		wp_enqueue_style( 'select2', PMPRO_URL . '/css/select2.min.css', '', '4.1.0-beta.0', 'screen' );


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-testimonials/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Resolves #24 

Remove all usage of now deprecated displayAtCheckout and build form fields

### How to test the changes in this Pull Request:

1. Go to frontend testimonial submission form
2. Submit with debug enabled
3. No more deprecation notices!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Testimonial submission form fields restructured to no longer use deprecated displayAtCheckout()