### PR TITLE
Change from "email" to "user_email"

### DIFF
--- a/includes/classes/pmpro-testimonial-form.php
+++ b/includes/classes/pmpro-testimonial-form.php
@@ -137,7 +137,7 @@ class PMPro_Testimonial_Form {
 											<?php esc_html_e( 'Name', 'pmpro-testimonials' );?>
 											<span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span>
 										</label>
-										<input id="display_name" type="text" name="display_name" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-required pmpro_form_input-text', 'display_name' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" <?php if ( $required ) { echo 'required'; } ?> />
+										<input id="display_name" type="text" name="display_name" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-required pmpro_form_input-text', 'display_name' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" required />
 									</div>
 
 									<?php

--- a/includes/classes/pmpro-testimonial-form.php
+++ b/includes/classes/pmpro-testimonial-form.php
@@ -195,7 +195,7 @@ class PMPro_Testimonial_Form {
 									$div_classes = array( 'pmpro_form_field', 'pmpro_form_field-user_email' );
 									$input_classes = array( 'pmpro_form_input' );
 									$required = false;
-									if ( in_array( 'email', $this->required_fields ) ) {
+									if ( in_array( 'user_email', $this->required_fields ) ) {
 										$required = true;
 										$div_classes[] = 'pmpro_form_field-required';
 										$input_classes[] = 'pmpro_form_input-required';
@@ -360,7 +360,7 @@ class PMPro_Testimonial_Form {
 			if ( empty( $_POST['display_name'] ) ) {
 				$error_fields[] = esc_html__( 'Name', 'pmpro-testimonials' );
 			}
-			if ( in_array( 'email', $this->required_fields ) && empty( $_POST['email'] ) ) {
+			if ( in_array( 'user_email', $this->required_fields ) && empty( $_POST['user_email'] ) ) {
 				$error_fields[] = esc_html__( 'Email', 'pmpro-testimonials' );
 			}
 			if ( in_array( 'job_title', $this->required_fields ) && empty( $_POST['job_title'] ) ) {

--- a/includes/classes/pmpro-testimonial-form.php
+++ b/includes/classes/pmpro-testimonial-form.php
@@ -93,7 +93,7 @@ class PMPro_Testimonial_Form {
 											<?php esc_html_e( 'Testimonial', 'pmpro-testimonials' );?>
 											<span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span>
 										</label>
-										<textarea id="testimonial" name="testimonial" rows="5" cols="80" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-textarea', 'testimonial' ) ); ?>"><?php echo ( ( ! empty( $_POST['testimonial'] ) ) ? esc_textarea( wp_unslash( $_POST['testimonial'] ) ) : '' );?></textarea>
+										<textarea id="testimonial" name="testimonial" rows="5" cols="80" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-textarea', 'testimonial' ) ); ?>" required><?php echo ( ( ! empty( $_POST['testimonial'] ) ) ? esc_textarea( wp_unslash( $_POST['testimonial'] ) ) : '' );?></textarea>
 									</div>
 
 									<?php
@@ -137,7 +137,7 @@ class PMPro_Testimonial_Form {
 											<?php esc_html_e( 'Name', 'pmpro-testimonials' );?>
 											<span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span>
 										</label>
-										<input id="display_name" type="text" name="display_name" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-required pmpro_form_input-text', 'display_name' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+										<input id="display_name" type="text" name="display_name" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-required pmpro_form_input-text', 'display_name' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" <?php if ( $required ) { echo 'required'; } ?> />
 									</div>
 
 									<?php
@@ -159,7 +159,7 @@ class PMPro_Testimonial_Form {
 											<?php esc_html_e( 'Job Title', 'pmpro-testimonials' );?>
 											<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
 										</label>
-										<input id="job_title" type="text" name="job_title" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $input_classes ), 'job_title' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+										<input id="job_title" type="text" name="job_title" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $input_classes ), 'job_title' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" <?php if ( $required ) { echo 'required'; } ?> />
 									</div>
 
 									<?php
@@ -181,7 +181,7 @@ class PMPro_Testimonial_Form {
 											<?php esc_html_e( 'Company', 'pmpro-testimonials' );?>
 											<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
 										</label>
-										<input id="company" type="text" name="company" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $input_classes ), 'company' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+										<input id="company" type="text" name="company" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $input_classes ), 'company' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" <?php if ( $required ) { echo 'required'; } ?> />
 									</div>
 
 									<?php
@@ -209,7 +209,7 @@ class PMPro_Testimonial_Form {
 											<?php esc_html_e( 'Email', 'pmpro-testimonials' );?>
 											<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
 										</label>
-										<input id="user_email" type="<?php echo ( $pmpro_email_field_type ? 'email' : 'text' ); ?>" name="user_email" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $input_classes ), 'user_email' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+										<input id="user_email" type="<?php echo ( $pmpro_email_field_type ? 'email' : 'text' ); ?>" name="user_email" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $input_classes ), 'user_email' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" <?php if ( $required ) { echo 'required'; } ?> />
 									</div>
 
 									<?php
@@ -231,7 +231,7 @@ class PMPro_Testimonial_Form {
 											<?php esc_html_e( 'URL', 'pmpro-testimonials' );?>
 											<?php if ( $required ) { ?><span class="<?php esc_attr_e( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'pmpro-testimonials' ); ?>">*</abbr></span><?php } ?>
 										</label>
-										<input id="url" type="url" name="url" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $input_classes ), 'url' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+										<input id="url" type="url" name="url" class="<?php echo esc_attr( pmpro_get_element_class( join( ' ', $input_classes ), 'url' ) ); ?>" value="<?php echo esc_attr( $value ); ?>" <?php if ( $required ) { echo 'required'; } ?> />
 									</div>
 
 									<?php

--- a/includes/classes/pmpro-testimonial-form.php
+++ b/includes/classes/pmpro-testimonial-form.php
@@ -42,6 +42,14 @@ class PMPro_Testimonial_Form {
 
 	}
 
+	/**
+	 * Display and process the testimonial form.
+	 * 
+	 * @since 0.1
+	 *
+	 * @param boolean $echo Whether to echo or return the form or success message (if form is processed.)
+	 * @return string $message|$form Returns the HTML for the confirmation message or the testimonial form.
+	 */
 	public function display( $echo = true ) {
 		global $current_user;
 

--- a/includes/classes/pmpro-testimonial.php
+++ b/includes/classes/pmpro-testimonial.php
@@ -144,6 +144,7 @@ class PMPro_Testimonial {
 		// If the user has an email, use Gravatar.
 		if ( $email = $this->get_email() ) {
 			$gravatar_url = get_avatar_url( strtolower( trim( $email ) ), array( 'default' => $default_image_url, 'size' => '150' ) );
+			_log( 'Gravatar URL: ' . $gravatar_url );
 			if ( $gravatar_url ) {
 				return sprintf(
 					'<img src="%s" alt="%s" style="%s" />',

--- a/includes/classes/pmpro-testimonial.php
+++ b/includes/classes/pmpro-testimonial.php
@@ -144,7 +144,6 @@ class PMPro_Testimonial {
 		// If the user has an email, use Gravatar.
 		if ( $email = $this->get_email() ) {
 			$gravatar_url = get_avatar_url( strtolower( trim( $email ) ), array( 'default' => $default_image_url, 'size' => '150' ) );
-			_log( 'Gravatar URL: ' . $gravatar_url );
 			if ( $gravatar_url ) {
 				return sprintf(
 					'<img src="%s" alt="%s" style="%s" />',

--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -29,12 +29,3 @@ function pmpro_testimonials_custom_query_loop_schema_attrs( $block_content, $blo
 	return $block_content;
 }
 add_filter( 'render_block', 'pmpro_testimonials_custom_query_loop_schema_attrs', 10, 2 );
-
-// Process the form submission.
-function pmpro_testimonials_process_form_submission() {
-	if ( ! empty( $_POST['pmpro_testimonials_nonce'] ) ) {
-		$form = new PMPro_Testimonial_Form();
-		$form->process();
-	}
-}
-add_action( 'wp', 'pmpro_testimonials_process_form_submission' );

--- a/includes/shortcodes/form.php
+++ b/includes/shortcodes/form.php
@@ -22,7 +22,9 @@ function pmpro_testimonials_shortcode_form( $atts ) {
 		$atts,
 		'pmpro_testimonials_form'
 	);
+	_log( $atts, 'Testimonial form shortcode atts before new class' );
 	$form = new PMPro_Testimonial_Form( $atts );
+	_log( $form, 'Testimonial form shortcode atts after new class' );
 	return $form->display( false );
 
 }

--- a/includes/shortcodes/form.php
+++ b/includes/shortcodes/form.php
@@ -1,7 +1,8 @@
 <?php
 /**
  * Shortcode to output a form for submitting testimonials.
- *
+ * NOTE: The display method will process the form.
+ * 
  * @param array $atts Shortcode attributes for categories, tags, required fields, and dropdown display.
  */
 function pmpro_testimonials_shortcode_form( $atts ) {

--- a/includes/shortcodes/form.php
+++ b/includes/shortcodes/form.php
@@ -22,9 +22,7 @@ function pmpro_testimonials_shortcode_form( $atts ) {
 		$atts,
 		'pmpro_testimonials_form'
 	);
-	_log( $atts, 'Testimonial form shortcode atts before new class' );
 	$form = new PMPro_Testimonial_Form( $atts );
-	_log( $form, 'Testimonial form shortcode atts after new class' );
 	return $form->display( false );
 
 }


### PR DESCRIPTION
When checking required fields, change it to check for "user_email" instead of just "email"

### All Submissions:

* [X] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-testimonials/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
